### PR TITLE
Avoid potential redefinition error of http_message_needs_eof during linking

### DIFF
--- a/src/third_party/http-parser/http_parser.c
+++ b/src/third_party/http-parser/http_parser.c
@@ -474,7 +474,7 @@ static struct {
 };
 #undef HTTP_STRERROR_GEN
 
-int http_message_needs_eof(const http_parser *parser);
+static int http_message_needs_eof(const http_parser *parser);
 
 /* Our URL parser.
  *


### PR DESCRIPTION
Using other libraries having the same http_parser shows linker error.
> multiple definition of `http_message_needs_eof'