### PR TITLE
tests: Integration tests working with Scylla

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,24 @@ int main(int argc, char* argv[]) {
 }
 ```
 
+## Testing
+
+This project includes a number of unit tests and an integration test suite. To run the integration tests against Scylla some prerequisites must be met:
+
+* `scylla-ccm` cloned and installed system-wide
+* `scylla-jmx` cloned alongside `scylla-ccm` and built
+* `scylla-tools-java` cloned, built and symlinked from `[SCYLLA_ROOT]/resources/cassandra`
+
+Building the integration tests:
+```
+mkdir build && cd build
+cmake -DCASS_BUILD_INTEGRATION_TESTS=ON .. && make
+```
+Certain test cases require features that are unavailable in OSS Scylla, or fail for other reasons, and thus need to be disabled for now. Assuming that `scylla` is built in the release mode, the command line may look as below:
+```
+./cassandra-integration-tests --install-dir=[SCYLLA_ROOT] --version=3.0.8 --category=CASSANDRA --verbose=ccm --gtest_filter=-AuthenticationTests*:ConsistencyTwoNodeClusterTests.Integration_Cassandra_SimpleEachQuorum:ControlConnectionTests.Integration_Cassandra_TopologyChange:ControlConnectionTwoNodeClusterTests.Integration_Cassandra_Reconnection:CustomPayloadTests*:DbaasTests*:DcAwarePolicyTest.Integration_Cassandra_UsedHostsRemoteDc:ExecutionProfileTest.Integration_Cassandra_RequestTimeout:ExecutionProfileTest.Integration_Cassandra_SpeculativeExecutionPolicy:MetricsTests.Integration_Cassandra_SpeculativeExecutionRequests:PreparedTests.Integration_Cassandra_PreparedIDUnchangedDuringReprepare:ServerSideFailureTests.Integration_Cassandra_Warning:ServerSideFailureTests.Integration_Cassandra_ErrorFunctionFailure:ServerSideFailureTests.Integration_Cassandra_ErrorFunctionAlreadyExists:SessionTest.Integration_Cassandra_ExternalHostListener:SchemaMetadataTest*:SchemaNullStringApiArgsTest*:SpeculativeExecutionTests*:SslTests*:SslClientAuthenticationTests*
+```
+
 ## License
 
 &copy; DataStax, Inc.
@@ -210,6 +228,8 @@ Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
+
+Modified by ScyllaDB &copy; 2020
 
 [Apache Cassandra®]: http://cassandra.apache.org
 [DataStax Enterprise]: http://www.datastax.com/products/datastax-enterprise

--- a/tests/src/integration/ccm/bridge.cpp
+++ b/tests/src/integration/ccm/bridge.cpp
@@ -13,6 +13,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
+// Copyright by ScyllaDB (c) 2020
 
 #ifdef _WIN32
 // Enable memory leak detection
@@ -300,6 +301,7 @@ bool CCM::Bridge::create_cluster(std::vector<unsigned short> data_center_nodes,
     // Create the cluster create command and execute
     std::vector<std::string> create_command;
     create_command.push_back("create");
+    create_command.push_back("--scylla");
     if (use_install_dir_ && !install_dir_.empty()) {
       create_command.push_back("--install-dir=" + install_dir_);
     } else {
@@ -1481,15 +1483,17 @@ CCM::Bridge::generate_create_updateconf_command(CassVersion cassandra_version) {
     }
   }
 
+  // Commented out for Scylla:
   // Create Cassandra version specific updated (C* 2.2+)
-  if (cassandra_version >= "2.2.0") {
-    updateconf_command.push_back("enable_user_defined_functions:true");
-  }
+  //if (cassandra_version >= "2.2.0") {
+  //  updateconf_command.push_back("experimental_features:udf");
+  //}
 
+  // Commented out for Scylla:
   // Create Cassandra version specific updated (C* 3.0+)
-  if (cassandra_version >= "3.0.0") {
-    updateconf_command.push_back("enable_scripted_user_defined_functions:true");
-  }
+  //if (cassandra_version >= "3.0.0") {
+  //  updateconf_command.push_back("enable_scripted_user_defined_functions:true");
+  //}
 
   return updateconf_command;
 }

--- a/tests/src/integration/ccm/bridge.hpp
+++ b/tests/src/integration/ccm/bridge.hpp
@@ -53,6 +53,8 @@ typedef struct _LIBSSH2_CHANNEL LIBSSH2_CHANNEL;
 #define DEFAULT_REMOTE_DEPLOYMENT_USERNAME "vagrant"
 #define DEFAULT_REMOTE_DEPLOYMENT_PASSWORD "vagrant"
 #define DEFAULT_IS_VERBOSE false
+#define DEFAULT_IS_SCYLLA true
+#define DEFAULT_SMP 1
 #define DEFAULT_JVM_ARGUMENTS std::vector<std::string>()
 
 // Define the node limit for a cluster
@@ -197,7 +199,8 @@ public:
          const std::string& username = DEFAULT_REMOTE_DEPLOYMENT_USERNAME,
          const std::string& password = DEFAULT_REMOTE_DEPLOYMENT_PASSWORD,
          const std::string& public_key = "", const std::string& private_key = "",
-         bool is_verbose = DEFAULT_IS_VERBOSE);
+         bool is_verbose = DEFAULT_IS_VERBOSE, bool is_scylla = DEFAULT_IS_SCYLLA,
+         int smp = DEFAULT_SMP);
 
   /**
    * Destructor
@@ -795,6 +798,14 @@ private:
    * Flag to determine if verbose output is enabled
    */
   bool is_verbose_;
+  /**
+   * Flag to determine if `--scylla` is passed to `ccm create`
+   */
+  bool is_scylla_;
+  /**
+   * Number of shards per host, passed to `ccm start` as JVM args (applies to Scylla).
+   */
+  int smp_;
 
 #ifdef CASS_USE_LIBSSH2
   /**

--- a/tests/src/integration/integration.cpp
+++ b/tests/src/integration/integration.cpp
@@ -156,7 +156,7 @@ void Integration::SetUp() {
           Options::dse_credentials(), Options::dse_username(), Options::dse_password(),
           Options::deployment_type(), Options::authentication_type(), Options::host(),
           Options::port(), Options::username(), Options::password(), Options::public_key(),
-          Options::private_key(), Options::is_verbose_ccm());
+          Options::private_key(), Options::is_verbose_ccm(), Options::is_scylla(), Options::smp());
       if (ccm_->create_cluster(data_center_nodes, is_with_vnodes_, is_password_authenticator_,
                                is_ssl_, is_client_authentication_)) {
         if (is_ccm_start_requested_) {

--- a/tests/src/integration/options.hpp
+++ b/tests/src/integration/options.hpp
@@ -234,6 +234,14 @@ public:
    */
   static bool is_beta_protocol();
   /**
+   * Flag to determine whether `--scylla` option should be passed to `ccm create`.
+   */
+  static bool is_scylla();
+  /**
+   * Requested number of shards per host, passed through JVM args in `ccm start`. Applies to Scylla.
+   */
+  static int smp();
+  /**
    * Get a CCM instance based on the options
    *
    * @return CCM instance
@@ -357,6 +365,14 @@ private:
    * NOTE: Individual tests can still override this.
    */
   static bool is_beta_protocol_;
+  /**
+   * Flag that passes `--scylla` to `ccm create` (or not). By default ON.
+   */
+  static bool is_scylla_;
+  /**
+   * Number of shards per host (applies to Scylla). By default 1.
+   */
+  static int smp_;
 
   /**
    * Hidden default constructor


### PR DESCRIPTION
This patch allows running cpp-driver's integration tests against Scylla and briefly describes this process. Features like downloading and running specific version/branch/tag were NOT tested (the documented process requires Scylla binaries at hand). It also adds the option to manipulate the `--smp` parameter which is useful for testing shard-awareness. Compatibility with C* can be restored with an option: `./cassandra-integration-tests --scylla=false ...`.

Since tests are written in C++98-ish dialect, I kept the ship on this course.