### PR TITLE
Host: `ShardingInfo` is copied under a mutex in getter

### DIFF
--- a/src/host.hpp
+++ b/src/host.hpp
@@ -133,7 +133,12 @@ public:
     dc_id_ = dc_id;
   }
 
-  CassOptional<ShardingInfo> sharding_info() const { return sharding_info_opt_; }
+  CassOptional<ShardingInfo> sharding_info() {
+    ScopedMutex lock(&mutex_);
+    auto tmp = sharding_info_opt_;
+    return tmp;
+  }
+
   void set_sharding_info_if_unset(ShardingInfo si) {
     ScopedMutex lock(&mutex_);
     if (!sharding_info_opt_) {


### PR DESCRIPTION
There was a possibility of race when `sharding_info_opt_` was concurrently set and get. That is, the getter might have observed incompletely assigned-to state.