### PR TITLE
Exchange connections upon non-advanced shard-aware connecting

### DIFF
--- a/src/connection_pool.hpp
+++ b/src/connection_pool.hpp
@@ -221,6 +221,11 @@ private:
   void internal_close();
   void maybe_closed();
 
+  /** Checks Host's marketplace (pool) for connections to trade with other ConnectionPools.
+   *  Returns true if its pool is satisfied with the number of open per-shard Connections. */
+  bool grab_unpooled_connections_from_host();
+  bool grab_unpooled_connections_from_host(int shard_id);
+
   void on_reconnect(DelayedConnector* connector);
 
 private:

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -308,7 +308,7 @@ void Connector::on_supported(ResponseMessage* response) {
                  socket_connector_->local_port(), *desired_shard_num_);
       }
     } else {
-      LOG_ERROR("Could not retrieve sharding info from control connection to %s."
+      LOG_ERROR("Could not retrieve sharding info from connection to %s."
                 " Continuing WITHOUT SHARD-AWARENESS.",
                 connection_->address().to_string().c_str());
     }

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -179,7 +179,7 @@ void Host::set(const Row* row, bool use_tokens) {
 
 std::list<Connection::Ptr> Host::get_unpooled_connections(int shard_id, int how_many) {
   ScopedMutex lock(&mutex_);
-  LOG_DEBUG("Requesting %d connections to shard %d on host %s from the marketplace", how_many, shard_id, address_.to_string().c_str());
+  LOG_DEBUG("Requesting %d connection(s) to shard %d on host %s from the marketplace", how_many, shard_id, address_.to_string(true).c_str());
   auto conn_list_to_selected_shard_it = unpooled_connections_per_shard_.find(shard_id);
   if (conn_list_to_selected_shard_it == unpooled_connections_per_shard_.end() || conn_list_to_selected_shard_it->second.empty()) {
     return {};
@@ -196,7 +196,7 @@ std::list<Connection::Ptr> Host::get_unpooled_connections(int shard_id, int how_
 
 void Host::add_unpooled_connection(Connection::Ptr conn) {
   ScopedMutex lock(&mutex_);
-  LOG_DEBUG("Connection marketplace consumes a connection to shard %d on host %s", conn->shard_id(), address_.to_string().c_str());
+  LOG_DEBUG("Connection marketplace consumes a connection to shard %d on host %s", conn->shard_id(), address_.to_string(true).c_str());
   unpooled_connections_per_shard_[conn->shard_id()].push_back(std::move(conn));
 }
 

--- a/src/host.hpp
+++ b/src/host.hpp
@@ -133,10 +133,6 @@ public:
   void set_sharding_info_if_unset(ShardingInfo si) {
     ScopedMutex lock(&mutex_);
     if (!sharding_info_opt_) {
-      if (si.shard_aware_port() || si.shard_aware_port_ssl()) {
-        const int remote_port = *(si.shard_aware_port() ? si.shard_aware_port() : si.shard_aware_port_ssl());
-        address_.set_port(remote_port);
-      }
       sharding_info_opt_ = std::move(si);
     }
   }

--- a/src/socket_connector.cpp
+++ b/src/socket_connector.cpp
@@ -178,8 +178,8 @@ void SocketConnector::internal_connect(uv_loop_t* loop) {
   const Address& local_address = settings_.local_address;
   if (local_address.is_valid()) {
     Address::SocketStorage storage;
-    LOG_DEBUG("Binding socket. local_address=%s:%d, remote=%s:%d",
-        local_address.to_string().c_str(), local_address.port(), socket_->address().to_string().c_str(), socket_->address().port());
+    LOG_DEBUG("Binding socket. local_address=%s, remote=%s",
+        local_address.to_string(true).c_str(), socket_->address().to_string(true).c_str());
     int rc = uv_tcp_bind(socket->handle(), local_address.to_sockaddr(&storage), 0);
     if (rc != 0) {
       on_error(SOCKET_ERROR_BIND, "Unable to bind local address: " + String(uv_strerror(rc)));

--- a/src/socket_connector.hpp
+++ b/src/socket_connector.hpp
@@ -137,6 +137,7 @@ public:
 
   void set_local_port(int port) { settings_.local_address.set_port(port); }
   int local_port() const { return settings_.local_address.port(); }
+  void set_remote_port(int port) { address_.set_port(port); }
 
 private:
   void internal_connect(uv_loop_t* loop);


### PR DESCRIPTION
This patch prevents "connection storm". It affects shard-aware clients who do NOT use port-based shard awareness (because of NAT or because of old version of Scylla). Such client opens connections until it reaches desired number of connections to particular shards. Now, if multithreaded, the client was prone to "shard oscillations": an undesirable phenomenon where one thread receives mostly connections to shard A and the other thread receives mostly connections to shard B. In effect, enormous numbers of connections would be established until the right shards are hit on both threads.

PR introduces "connection marketplace", associated with every `Host`, where `ConnectionPool`s from different threads can exchange their `Connection`s. Because of the "unorchestrated" architecture of `ConnectionPoolManager`, sometimes more connections are opened than necessary. These are not used, but are kept in the marketplace for the lifetime of any involved `ConnectionPool`.