### PR TITLE
logger: restore Logger and logging callback on integ. test teardown

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -11299,6 +11299,15 @@ cass_log_set_callback(CassLogCallback callback,
                       void* data);
 
 /**
+ * Analogous getter - useful for restoring logger to previous values.
+ * 
+ * @param[out] callback_out Current logging callback. Must point to a valid memory area.
+ * @param[out] data_out Current Logger instance. Must point to a valid memory area.
+ */
+CASS_EXPORT void
+cass_log_get_callback_and_data(CassLogCallback* callback_out, void** data_out);
+
+/**
  * Sets the log queue size.
  *
  * <b>Note:</b> This needs to be done before any call that might log, such as

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -30,6 +30,10 @@ void cass_log_set_callback(CassLogCallback callback, void* data) {
   Logger::set_callback(callback, data);
 }
 
+void cass_log_get_callback_and_data(CassLogCallback* callback_out, void** data_out) {
+  Logger::get_callback_and_data(callback_out, data_out);
+}
+
 void cass_log_set_queue_size(size_t queue_size) {
   // Deprecated
 }
@@ -65,4 +69,9 @@ void Logger::set_log_level(CassLogLevel log_level) { log_level_ = log_level; }
 void Logger::set_callback(CassLogCallback cb, void* data) {
   cb_ = cb == NULL ? noop_log_callback : cb;
   data_ = data;
+}
+
+void Logger::get_callback_and_data(CassLogCallback* cb_out, void** data_out) {
+  *cb_out = cb_;
+  *data_out = data_;
 }

--- a/src/logger.hpp
+++ b/src/logger.hpp
@@ -31,6 +31,7 @@ class Logger {
 public:
   static void set_log_level(CassLogLevel level);
   static void set_callback(CassLogCallback cb, void* data);
+  static void get_callback_and_data(CassLogCallback* cb_out, void** data_out);
 
 #if defined(__GNUC__) || defined(__clang__)
 #define ATTR_FORMAT(string, first) __attribute__((__format__(__printf__, string, first)))

--- a/tests/src/integration/logger.cpp
+++ b/tests/src/integration/logger.cpp
@@ -44,6 +44,10 @@ Logger::~Logger() {
   if (output_.is_open()) {
     output_.close();
   }
+  if (restore_old_logger_) {
+    // `initialize` has beed called, so let's restore global logger
+    cass_log_set_callback(old_log_callback_, old_data_);
+  }
 }
 
 void Logger::initialize(const std::string& test_case, const std::string& test_name) {
@@ -72,6 +76,10 @@ void Logger::initialize(const std::string& test_case, const std::string& test_na
 
   // Set the maximum driver log level to capture all logs messages
   cass_log_set_level(CASS_LOG_TRACE);
+
+  // Remember the old logger before setting it (to be restored in dtor)
+  cass_log_get_callback_and_data(&old_log_callback_, &old_data_);
+  restore_old_logger_ = true;
   cass_log_set_callback(Logger::log, this);
 }
 

--- a/tests/src/integration/logger.hpp
+++ b/tests/src/integration/logger.hpp
@@ -97,6 +97,11 @@ private:
    * Number of log messages that match the search criteria
    */
   size_t count_;
+  
+  /** We need these to restore the globals on teardown. */
+  bool restore_old_logger_ = false;
+  CassLogCallback old_log_callback_;
+  void* old_data_;
 
   /**
    * Log the message from the driver (callback)


### PR DESCRIPTION
When integration test gets constructed, it can set global `cb_` and
`data_` to temporaries. After the test finishes and temporaries are
destroyed, the next tests ctor may try to refer to them (before it
sets the globals by itself).

This happened in the ctor of `Random`, which logged a message in
case of failure. Sometimes this manifested as segfault, sometimes
as a deadlock. This fix restores the old logger values on test teardown -
- most likely to stderr.

Fixes #13