### PR TITLE
Replace upstream links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ Doxyfile
 docs/_build
 docs/source/.doctrees
 docs/_source
+docs/source/api
 docs/poetry.lock
 doxygen
 # editor

--- a/README.md
+++ b/README.md
@@ -185,17 +185,17 @@ Modified by ScyllaDB &copy; 2020
 
 [ScyllaDB]: http://scylladb.com
 [DataStax Enterprise]: http://www.datastax.com/products/datastax-enterprise
-[Examples]: examples/
+[Examples]: https://github.com/scylladb/cpp-driver/tree/master/examples
 [GitHub]: https://github.com/scylladb/cpp-driver
 [Home]: http://docs.datastax.com/en/developer/cpp-driver/latest
 [API]: http://docs.datastax.com/en/developer/cpp-driver/latest/api
 [Getting Started]: https://university.scylladb.com/courses/using-scylla-drivers/lessons/cpp-driver-part-1/
 [Building]: http://docs.datastax.com/en/developer/cpp-driver/latest/topics/building
 [Provide your input]: http://goo.gl/forms/ihKC5uEQr6
-[Installation]:topics/index.html#installation
+[Installation]: topics/
 [Kerberos]: https://web.mit.edu/kerberos
 
-[Shard-Awareness]:topics/scylla_specific/index.html
+[Shard-Awareness]:topics/scylla_specific/
 [Asynchronous API]: http://datastax.github.io/cpp-driver/topics/#futures
 [Simple]: http://datastax.github.io/cpp-driver/topics/#executing-queries
 [Prepared]: http://datastax.github.io/cpp-driver/topics/basics/prepared_statements/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -36,7 +36,7 @@ clean:
 
 .PHONY: preview
 preview: setup
-	$(POETRY) run sphinx-autobuild -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml --port 5500
+	$(POETRY) run sphinx-autobuild -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml --port 5500 --re-ignore api/*
 
 .PHONY: dirhtml
 dirhtml: setup

--- a/docs/source/api/cassandra.h.rst
+++ b/docs/source/api/cassandra.h.rst
@@ -1,5 +1,0 @@
-cassandra.h
-===========
-
-.. doxygenfile:: cassandra.h
-  :project: API

--- a/docs/source/api/dse.h.rst
+++ b/docs/source/api/dse.h.rst
@@ -1,5 +1,0 @@
-dse.h
-=====
-
-.. doxygenfile:: dse.h
-  :project: API


### PR DESCRIPTION
Closes #24 

Replaces automatically the links all the links with the form http://datastax.github.io/cpp-driver/* and http://docs.datastax.com/en/developer/cpp-driver/* to https://cpp-driver.docs.scylladb.com/*.

## How to test this PR

1. Enter the docs folder with ``cd docs``
2. Run ``make preview`` and open the documentation in your browser.
3. Under "Features", click on "Asynchronous API". 

![tempsnip](https://user-images.githubusercontent.com/9107969/109012527-037d6700-76aa-11eb-991d-8a349b7cc3b6.png)

As you can see in the screenshot, this is defined as a [Datastax link](https://github.com/scylladb/cpp-driver/compare/master...dgarcia360:replace-links?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R199), but when you click on it should redirect
 you to https://cpp-driver.docs.scylladb.com/master/topics/#futures