### PR TITLE
protocol_version: Use non-DSE protocols by default

### DIFF
--- a/src/protocol.hpp
+++ b/src/protocol.hpp
@@ -58,7 +58,7 @@ public:
    * Apache Cassandra version is returned.
    * @return The highest protocol version.
    */
-  static ProtocolVersion highest_supported(bool is_dse = true);
+  static ProtocolVersion highest_supported(bool is_dse = false);
 
   /**
    * Returns the newest supported beta protocol version.


### PR DESCRIPTION
This caused errors on startup (harmless but bad looking):

```
1591782949.062 [ERROR] (cluster_connector.cpp:192:void datastax::internal::core::ClusterConnector::on_connect(datastax::internal::core::ControlConnector*)): Unable to establish a control connection to host 172.21.0.2 because of the following error: Underlying connection error: Received error response 'Invalid or unsupported protocol version: 66' (0x0200000A)
1591782949.062 [WARN] (cluster_connector.cpp:289:void datastax::internal::core::ClusterConnector::on_connect(datastax::internal::core::ControlConnector*)): Host 172.21.0.2 does not support protocol version DSEv2. Trying protocol version DSEv1...
1591782949.062 [ERROR] (cluster_connector.cpp:192:void datastax::internal::core::ClusterConnector::on_connect(datastax::internal::core::ControlConnector*)): Unable to establish a control connection to host 172.21.0.2 because of the following error: Underlying connection error: Received error response 'Invalid or unsupported protocol version: 65' (0x0200000A)
1591782949.062 [WARN] (cluster_connector.cpp:289:void datastax::internal::core::ClusterConnector::on_connect(datastax::internal::core::ControlConnector*)): Host 172.21.0.2 does not support protocol version DSEv1. Trying protocol version v4...
```

Fixes #29