### PR TITLE
Fixed crash when using marketplace.

### DIFF
--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -40,6 +40,15 @@ public:
   virtual void on_read(Socket* socket, ssize_t nread, const uv_buf_t* buf);
   virtual void on_write(Socket* socket, int status, SocketRequest* request);
   virtual void on_close();
+  /**
+   * Method used by connection-exporting mechanism (moving 
+   * connections between event loops). As the new Connection object is
+   * constructed during such move, we need to be able to change
+   * object referenced by handler.
+   */
+  void set_connection(Connection *connection) {
+    this->connection_ = connection;
+  };
 
 private:
   Connection* connection_;
@@ -57,6 +66,15 @@ public:
   virtual void on_ssl_read(Socket* socket, char* buf, size_t size);
   virtual void on_write(Socket* socket, int status, SocketRequest* request);
   virtual void on_close();
+  /**
+   * Method used by connection-exporting mechanism (moving 
+   * connections between event loops). As the new Connection object is
+   * constructed during such move, we need to be able to change
+   * object referenced by handler.
+   */
+  void set_connection(Connection *connection) {
+    this->connection_ = connection;
+  };
 
 private:
   Connection* connection_;
@@ -124,6 +142,7 @@ class Connection : public RefCounted<Connection> {
   friend class ConnectionHandler;
   friend class SslConnectionHandler;
   friend class HeartbeatCallback;
+  friend class ExportedConnection;
 
 public:
   typedef SharedRefPtr<Connection> Ptr;

--- a/src/connection_pool.hpp
+++ b/src/connection_pool.hpp
@@ -167,7 +167,7 @@ public:
   void set_listener(ConnectionPoolListener* listener = NULL);
 
 public:
-  const uv_loop_t* loop() const { return loop_; }
+  uv_loop_t* loop() { return loop_; }
   const Address& address() const { return host_->address(); }
   ProtocolVersion protocol_version() const { return protocol_version_; }
   const String& keyspace() const { return keyspace_; }

--- a/src/exported_connection.cpp
+++ b/src/exported_connection.cpp
@@ -1,0 +1,72 @@
+#include <unistd.h>
+
+#include "exported_connection.hpp"
+#include "connection.hpp"
+
+
+namespace datastax { namespace internal { namespace core {
+
+ExportedConnection::ExportedConnection(SharedRefPtr<Connection> connection) {
+    // Connection
+    this->host = connection->host();
+    this->listener_ = connection->listener_;
+    // We don't want to notify higher layers of code
+    // that connection has been closed.
+    connection->set_listener();
+    this->protocol_version_ = connection->protocol_version();
+    this->keyspace_ = connection->keyspace();
+    this->shard_id_ = connection->shard_id();
+    this->idle_timeout_secs_ = connection->idle_timeout_secs_;
+    this->heartbeat_interval_secs_ = connection->heartbeat_interval_secs_;
+
+    // Socket
+    uv_fileno(reinterpret_cast<uv_handle_t *>(&connection->socket_->tcp_), &this->fd);
+    this->fd = dup(this->fd);
+    this->handler_ = connection->socket_->handler_.release();
+    // Set basic handler, to notify Connection about closing, and destroy it.
+    connection->socket_->set_handler(new ConnectionHandler(connection.get()));
+    this->is_defunct_ = connection->socket_->is_defunct();
+    this->max_reusable_write_objects_ = connection->socket_->max_reusable_write_objects_;
+    this->address_ = connection->socket_->address();
+
+    connection->close();
+}
+
+ExportedConnection::~ExportedConnection() {
+    if(handler_) {
+        delete handler_;
+    }
+}
+
+SharedRefPtr<Connection> ExportedConnection::import_connection(uv_loop_t *loop) {
+    Socket::Ptr socket_(new Socket(this->address_, this->max_reusable_write_objects_));
+    if (uv_tcp_init(loop, socket_->handle()) != 0) {
+        return Connection::Ptr();
+    }
+    socket_->is_defunct_ = this->is_defunct_;
+    uv_tcp_open(socket_->handle(), this->fd);
+
+    Connection::Ptr connection_(new Connection(socket_, this->host, this->protocol_version_, this->idle_timeout_secs_,
+                                     this->heartbeat_interval_secs_));
+    connection_->set_listener(this->listener_);
+    connection_->keyspace_ = keyspace_;
+    connection_->set_shard_id(this->shard_id_);
+
+    ConnectionHandler *c_handler = dynamic_cast<ConnectionHandler *>(this->handler_);
+    SslConnectionHandler *s_handler = dynamic_cast<SslConnectionHandler *>(this->handler_);
+    if (c_handler != nullptr) {
+        c_handler->set_connection(connection_.get());
+    } else if (s_handler != nullptr) {
+        s_handler->set_connection(connection_.get());
+    } else {
+        return Connection::Ptr();
+    }
+    socket_->set_handler(this->handler_);
+    this->handler_ = nullptr;
+
+    socket_->inc_ref();
+
+    return connection_;
+}
+
+}}}  // namespace datastax::internal::core

--- a/src/exported_connection.hpp
+++ b/src/exported_connection.hpp
@@ -1,0 +1,52 @@
+#ifndef DATASTAX_EXPORTED_CONNECTION_HPP
+#define DATASTAX_EXPORTED_CONNECTION_HPP
+
+#include "ref_counted.hpp"
+#include "protocol.hpp"
+#include "address.hpp"
+
+namespace datastax { namespace internal { namespace core {
+
+class Host;
+class Connection;
+class ConnectionListener;
+class SocketHandlerBase;
+
+/**
+ * This class is a hack that allows moving Connection to
+ * different event loop. libuv doesn't have any mechanism
+ * to do that (https://github.com/libuv/libuv/issues/390).
+ * The solution used here is to extract file descriptor from Connection,
+ * along with some important fields of Connection and Socket,
+ * duplicate fd it using `dup` syscall, close and destroy original Connection,
+ * and then on destination event loop create new Coonnection and Socket objects,
+ * restoring their state from saved fields.
+ */
+class ExportedConnection : public RefCounted<ExportedConnection> {
+public:
+    typedef SharedRefPtr<ExportedConnection> Ptr;
+    ExportedConnection(SharedRefPtr<Connection> connection);
+    ~ExportedConnection();
+    SharedRefPtr<Connection> import_connection(uv_loop_t *loop);
+
+private:
+    // Connection fields
+    SharedRefPtr<Host> host;
+    ConnectionListener* listener_;
+    ProtocolVersion protocol_version_;
+    String keyspace_;
+    int32_t shard_id_ = 0;
+    unsigned int idle_timeout_secs_;
+    unsigned int heartbeat_interval_secs_;
+
+    // Socket fields
+    int fd;
+    SocketHandlerBase *handler_;
+    bool is_defunct_;
+    size_t max_reusable_write_objects_;
+    Address address_;
+};
+
+}}}  // namespace datastax::internal::core
+
+#endif

--- a/src/host.hpp
+++ b/src/host.hpp
@@ -32,6 +32,7 @@
 #include "vector.hpp"
 #include "sharding_info.hpp"
 #include "optional.hpp"
+#include "exported_connection.hpp"
 
 #include <list>
 #include <math.h>
@@ -186,9 +187,9 @@ public:
    * within one instance of `Host`, so one thread can make use of a connection
    * that didn't fit into another thread's `ConnectionPool`.
    */
-  std::list<SharedRefPtr<Connection>> get_unpooled_connections(int shard_id, int how_many);
+  std::list<SharedRefPtr<ExportedConnection>> get_unpooled_connections(int shard_id, int how_many);
   void add_unpooled_connection(SharedRefPtr<Connection> conn);
-  void close_unpooled_connections();
+  void close_unpooled_connections(uv_loop_t *loop);
 
   void increment_inflight_requests() { inflight_request_count_.fetch_add(1, MEMORY_ORDER_RELAXED); }
 
@@ -240,7 +241,7 @@ private:
   ScopedPtr<LatencyTracker> latency_tracker_;
 
   uv_mutex_t mutex_;
-  std::map<int, std::list<SharedRefPtr<Connection>>> unpooled_connections_per_shard_;
+  std::map<int, std::list<SharedRefPtr<ExportedConnection>>> unpooled_connections_per_shard_;
 
 private:
   DISALLOW_COPY_AND_ASSIGN(Host);

--- a/src/socket.hpp
+++ b/src/socket.hpp
@@ -273,6 +273,7 @@ protected:
 class Socket : public RefCounted<Socket> {
   friend class SocketConnector;
   friend class SocketWriteBase;
+  friend class ExportedConnection;
 
 public:
   typedef SharedRefPtr<Socket> Ptr;


### PR DESCRIPTION
Non-advanced shard-awarness is using marketplace mechanism,
to let threads give out connections to other threads.
This was causing segmentation faults because using libuv's event loop
apis from a different thread than the loop is running on is
unsupported. Unfortunately libuv doesn't have any mechanism to move
handle to a different event loop, so I had to resort to a dirty hack:
extract fd from handle, dup() this fd, and then reconstruct object in
a different event loop. This seems to work, altough it is very fragile,
because changes to Connection/Socket classes are likely to break this fix.

Fixes #36 