### PR TITLE
Cluster: do not prolong the lifetime of Cluster for PrepareHostHandler

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -520,7 +520,7 @@ void Cluster::internal_notify_host_up(const Address& address) {
     return; // Ignore host
   }
 
-  if (!prepare_host(host, bind_callback(&Cluster::on_prepare_host_up, Cluster::Ptr(this)))) {
+  if (!prepare_host(host, bind_callback(&Cluster::on_prepare_host_up, this))) {
     notify_host_up_after_prepare(host);
   }
 }
@@ -613,7 +613,7 @@ void Cluster::notify_host_add(const Host::Ptr& host) {
     return; // Ignore host
   }
 
-  if (!prepare_host(host, bind_callback(&Cluster::on_prepare_host_add, Cluster::Ptr(this)))) {
+  if (!prepare_host(host, bind_callback(&Cluster::on_prepare_host_add, this))) {
     notify_host_add_after_prepare(host);
   }
 }


### PR DESCRIPTION
It was supposed to fix a crash when "host up" event interleaves with
the destruction of Cluster object, but it introduced another bug, which
can be observed e.g. in ControlConnectionTests.Integration_Cassandra_FullOutage
integration test. The bug is that `EventLoop` still has working "timer handle"
while being destroyed and, in turn, segfaults.

This PR restores the old behavior.