### PR TITLE
Fixed building driver with clang

### DIFF
--- a/src/optional/optional_akrzemi.hpp
+++ b/src/optional/optional_akrzemi.hpp
@@ -219,7 +219,7 @@ template <class T> inline constexpr typename std::remove_reference<T>::type&& co
 #if defined NDEBUG
 # define TR2_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) (EXPR)
 #else
-# define TR2_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) ((CHECK) ? (EXPR) : ([]{assert(!#CHECK);}(), (EXPR)))
+# define TR2_OPTIONAL_ASSERTED_EXPRESSION(CHECK, EXPR) ((CHECK) ? (EXPR) : ([]{assert(((void)#CHECK, false));}(), (EXPR)))
 #endif
 
 


### PR DESCRIPTION
Implicitly converting string literal to bool warns on clang,
and this warn was turned to error because of -Werror.