### PR TITLE
Make Cluster owner of EventLoop

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -262,6 +262,13 @@ Cluster::Cluster(const ControlConnection::Ptr& connection, ClusterListener* list
   listener_->on_reconnect(this);
 }
 
+Cluster::~Cluster() {
+  if (event_loop_) {
+    event_loop_->close_handles();
+    event_loop_->join();
+  }
+}
+
 void Cluster::close() { event_loop_->add(new ClusterRunClose(Ptr(this))); }
 
 void Cluster::notify_host_up(const Address& address) {
@@ -520,7 +527,7 @@ void Cluster::internal_notify_host_up(const Address& address) {
     return; // Ignore host
   }
 
-  if (!prepare_host(host, bind_callback(&Cluster::on_prepare_host_up, this))) {
+  if (!prepare_host(host, bind_callback(&Cluster::on_prepare_host_up, Cluster::Ptr(this)))) {
     notify_host_up_after_prepare(host);
   }
 }
@@ -613,7 +620,7 @@ void Cluster::notify_host_add(const Host::Ptr& host) {
     return; // Ignore host
   }
 
-  if (!prepare_host(host, bind_callback(&Cluster::on_prepare_host_add, this))) {
+  if (!prepare_host(host, bind_callback(&Cluster::on_prepare_host_add, Cluster::Ptr(this)))) {
     notify_host_add_after_prepare(host);
   }
 }

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -269,6 +269,8 @@ public:
           const LoadBalancingPolicy::Vec& load_balancing_policies, const String& local_dc,
           const StringMultimap& supported_options, const ClusterSettings& settings);
 
+  virtual ~Cluster();
+
   /**
    * Set the listener that will handle events for the cluster
    * (*NOT* thread-safe).
@@ -437,7 +439,7 @@ private:
   ControlConnection::Ptr connection_;
   ControlConnector::Ptr reconnector_;
   ClusterListener* listener_;
-  EventLoop* const event_loop_;
+  ScopedPtr<EventLoop> event_loop_;
   const LoadBalancingPolicy::Ptr load_balancing_policy_;
   LoadBalancingPolicy::Vec load_balancing_policies_;
   const ClusterSettings settings_;

--- a/src/cluster_connector.cpp
+++ b/src/cluster_connector.cpp
@@ -118,13 +118,13 @@ void ClusterConnector::internal_resolve_and_connect() {
   resolver_ = settings_.cluster_metadata_resolver_factory->new_instance(settings_);
 
   resolver_->resolve(event_loop_->loop(), contact_points_,
-                     bind_callback(&ClusterConnector::on_resolve, this));
+                     bind_callback(&ClusterConnector::on_resolve, Ptr(this)));
 }
 
 void ClusterConnector::internal_connect(const Address& address, ProtocolVersion version) {
   Host::Ptr host(new Host(address));
   ControlConnector::Ptr connector(
-      new ControlConnector(host, version, bind_callback(&ClusterConnector::on_connect, this)));
+      new ControlConnector(host, version, bind_callback(&ClusterConnector::on_connect, Ptr(this))));
   connectors_[address] = connector; // Keep track of the connectors so they can be canceled.
   connector->with_metrics(metrics_)
       ->with_settings(settings_.control_connection_settings)

--- a/src/cluster_connector.hpp
+++ b/src/cluster_connector.hpp
@@ -65,6 +65,11 @@ public:
                    const Callback& callback);
 
   /**
+   * Destructor - it needs to close and join event loop if it wasn't passed to Cluster.
+   */
+  virtual ~ClusterConnector();
+
+  /**
    * Set the cluster listener to use for handle cluster events.
    *
    * @param listener A listener that handles cluster events.
@@ -165,7 +170,7 @@ private:
   AddressVec contact_points_;
   ProtocolVersion protocol_version_;
   ClusterListener* listener_;
-  EventLoop* event_loop_;
+  ScopedPtr<EventLoop> event_loop_;
   Random* random_;
   Metrics* metrics_;
   String local_dc_;

--- a/src/session_base.hpp
+++ b/src/session_base.hpp
@@ -150,7 +150,6 @@ private:
 private:
   mutable uv_mutex_t mutex_;
   State state_;
-  ScopedPtr<EventLoop> event_loop_;
   Cluster::Ptr cluster_;
   Config config_;
   ScopedPtr<Random> random_;


### PR DESCRIPTION
Previously, SessionBase was owner of EventLoop, and Cluster only held
non-owning (raw) pointer. It was possible for SessionBase to get
destroyed, while Cluster was still alive, with some handles still in
EventLoop, preventing this loops, and SessionBase, destruction.
This commit fixes the owenership, and also re-applies previous fix:
https://datastax-oss.atlassian.net/browse/CPP-924
In other words, reverts https://github.com/scylladb/cpp-driver/pull/45