### PR TITLE
Install exports

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -282,6 +282,11 @@ if(CASS_BUILD_SHARED)
     NAMESPACE ScyllaCppDriver::
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ScyllaCppDriver
   )
+  # Export our library target so someone can build it as part of their build
+  export(EXPORT ScyllaCppDriver
+       FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/ScyllaCppDriver.cmake"
+       NAMESPACE ScyllaCppDriver::
+  )
   if(CASS_INSTALL_PKG_CONFIG)
     if(NOT WIN32)
       if(PKG_CONFIG_FOUND)
@@ -309,6 +314,11 @@ if(CASS_BUILD_STATIC)
     FILE ScyllaCppDriverStatic.cmake
     NAMESPACE ScyllaCppDriverStatic::
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ScyllaCppDriverStatic
+  )
+  # Export our library target so someone can build it as part of their build
+  export(EXPORT ScyllaCppDriverStatic
+       FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/ScyllaCppDriverStatic.cmake"
+       NAMESPACE ScyllaCppDriverStatic::
   )
   if(CASS_INSTALL_PKG_CONFIG)
     if(NOT WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -272,9 +272,16 @@ endif()
 # Install the dynamic/shared library
 if(CASS_BUILD_SHARED)
   install(TARGETS scylla-cpp-driver
+    EXPORT ScyllaCppDriver
     RUNTIME DESTINATION ${INSTALL_DLL_EXE_DIR}  # for dll/executable/pdb files
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}  # for shared library
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}) # for static library
+  # Install the export file
+  install(EXPORT ScyllaCppDriver
+    FILE ScyllaCppDriver.cmake
+    NAMESPACE ScyllaCppDriver::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ScyllaCppDriver
+  )
   if(CASS_INSTALL_PKG_CONFIG)
     if(NOT WIN32)
       if(PKG_CONFIG_FOUND)
@@ -293,9 +300,16 @@ endif()
 
 if(CASS_BUILD_STATIC)
   install(TARGETS cassandra_static
+    EXPORT ScyllaCppDriverStatic
     RUNTIME DESTINATION ${INSTALL_DLL_EXE_DIR}  # for dll/executable/pdb files
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}  # for shared library
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}) # for static library
+  
+  install(EXPORT ScyllaCppDriverStatic
+    FILE ScyllaCppDriverStatic.cmake
+    NAMESPACE ScyllaCppDriverStatic::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ScyllaCppDriverStatic
+  )
   if(CASS_INSTALL_PKG_CONFIG)
     if(NOT WIN32)
       if(PKG_CONFIG_FOUND)


### PR DESCRIPTION
closes #52 

MR to allow target export of the CPP driver (allows another project to build as part of their build, which is a primary usecase for the scylla driver). Additionally, adds install export function which allows other code to more easily import the cpp driver once it's installed.