### PR TITLE
Fix broken links

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -195,30 +195,30 @@ Modified by ScyllaDB &copy; 2020
 [Kerberos]: https://web.mit.edu/kerberos
 
 [Shard-Awareness]:topics/scylla_specific/
-[Asynchronous API]: http://datastax.github.io/cpp-driver/topics/#futures
-[Simple]: http://datastax.github.io/cpp-driver/topics/#executing-queries
-[Prepared]: http://datastax.github.io/cpp-driver/topics/basics/prepared_statements/
-[Batch]: http://datastax.github.io/cpp-driver/topics/basics/batches/
-[Asynchronous I/O]: http://datastax.github.io/cpp-driver/topics/#asynchronous-i-o
-[parallel execution]: http://datastax.github.io/cpp-driver/topics/#thread-safety
-[load balancing]: http://datastax.github.io/cpp-driver/topics/configuration/#load-balancing
-[Authentication]: http://datastax.github.io/cpp-driver/topics/security/#authentication
-[SSL]: http://datastax.github.io/cpp-driver/topics/security/ssl/
-[Latency-aware routing]: http://datastax.github.io/cpp-driver/topics/configuration/#latency-aware-routing
-[Performance metrics]: http://datastax.github.io/cpp-driver/topics/metrics/
-[Tuples]: http://datastax.github.io/cpp-driver/topics/basics/tuples/
-[UDTs]: http://datastax.github.io/cpp-driver/topics/basics/user_defined_types/
-[Nested collections]: http://datastax.github.io/cpp-driver/topics/basics/binding_parameters/#nested-collections
-[Data types]: http://datastax.github.io/cpp-driver/topics/basics/data_types/
-[Retry policies]: http://datastax.github.io/cpp-driver/topics/configuration/retry_policies/
-[Client-side timestamps]: http://datastax.github.io/cpp-driver/topics/basics/client_side_timestamps/
-[Idle connection heartbeats]: http://datastax.github.io/cpp-driver/topics/configuration/#connection-heartbeats
-[Blacklist]: http://datastax.github.io/cpp-driver/topics/configuration/#blacklist
-[whitelist DC]: http://datastax.github.io/cpp-driver/topics/configuration/#datacenter
-[blacklist DC]: http://datastax.github.io/cpp-driver/topics/configuration/#datacenter
-[Custom]: http://datastax.github.io/cpp-driver/topics/security/#custom
-[Reverse DNS]: http://datastax.github.io/cpp-driver/topics/security/ssl/#enabling-cassandra-identity-verification
-[Speculative execution]: http://datastax.github.io/cpp-driver/topics/configuration/#speculative-execution
+[Asynchronous API]: http://datastax.github.io/cpp-driver/topics#futures
+[Simple]: http://datastax.github.io/cpp-driver/topics#executing-queries
+[Prepared]: http://datastax.github.io/cpp-driver/topics/basics/prepared_statements
+[Batch]: http://datastax.github.io/cpp-driver/topics/basics/batches
+[Asynchronous I/O]: http://datastax.github.io/cpp-driver/topics#asynchronous-i-o
+[parallel execution]: http://datastax.github.io/cpp-driver/topics#thread-safety
+[load balancing]: http://datastax.github.io/cpp-driver/topics/configuration#load-balancing
+[Authentication]: http://datastax.github.io/cpp-driver/topics/security#authentication
+[SSL]: http://datastax.github.io/cpp-driver/topics/security/ssl
+[Latency-aware routing]: http://datastax.github.io/cpp-driver/topics/configuration#latency-aware-routing
+[Performance metrics]: http://datastax.github.io/cpp-driver/topics/metrics
+[Tuples]: http://datastax.github.io/cpp-driver/topics/basics/tuples
+[UDTs]: http://datastax.github.io/cpp-driver/topics/basics/user_defined_types
+[Nested collections]: http://datastax.github.io/cpp-driver/topics/basics/binding_parameters#nested-collections
+[Data types]: http://datastax.github.io/cpp-driver/topics/basics/data_types
+[Retry policies]: http://datastax.github.io/cpp-driver/topics/configuration/retry_policies
+[Client-side timestamps]: http://datastax.github.io/cpp-driver/topics/basics/client_side_timestamps
+[Idle connection heartbeats]: http://datastax.github.io/cpp-driver/topics/configuration#connection-heartbeats
+[Blacklist]: http://datastax.github.io/cpp-driver/topics/configuration#blacklist
+[whitelist DC]: http://datastax.github.io/cpp-driver/topics/configuration#datacenter
+[blacklist DC]: http://datastax.github.io/cpp-driver/topics/configuration#datacenter
+[Custom]: http://datastax.github.io/cpp-driver/topics/security#custom
+[Reverse DNS]: http://datastax.github.io/cpp-driver/topics/security/ssl#enabling-cassandra-identity-verification
+[Speculative execution]: http://datastax.github.io/cpp-driver/topics/configuration#speculative-execution
 [Using Scylla Drivers]: https://university.scylladb.com/courses/using-scylla-drivers/
 [CPP Driver - Part 1]: https://university.scylladb.com/courses/using-scylla-drivers/lessons/cpp-driver-part-1/
 [Scylla University]: https://university.scylladb.com/

--- a/topics/README.md
+++ b/topics/README.md
@@ -299,7 +299,7 @@ with other drivers. Such features can be found (and requested) on our [GH].
 [built from source]: http://github.com/scylladb/cpp-driver/tree/master/topics/building/
 [prepared statements]: http://github.com/scylladb/cpp-driver/tree/master/topics/basics/prepared_statements/
 [`cass_int32_t`]: http://datastax.github.io/cpp-driver/api/cassandra.h#cass-int32-t
-[`cass_result_first_row()`]: http://datastax.github.io/cpp-driver/api/struct.CassResult/#cass-result-first-row
+[`cass_result_first_row()`]: http://datastax.github.io/cpp-driver/api/struct.CassResult#cass-result-first-row
 [`cass_cluster_set_num_threads_io()`]: http://datastax.github.io/cpp-driver/api/struct.CassCluster#function-cass_cluster_set_num_threads_io
 [`CassCluster`]: http://datastax.github.io/cpp-driver/api/struct.CassCluster
 [`CassFuture`]: http://datastax.github.io/cpp-driver/api/struct.CassFuture

--- a/topics/README.md
+++ b/topics/README.md
@@ -298,14 +298,14 @@ with other drivers. Such features can be found (and requested) on our [GH].
 [cpp-driver-releases]: https://github.com/scylladb/cpp-driver/releases
 [built from source]: http://github.com/scylladb/cpp-driver/tree/master/topics/building/
 [prepared statements]: http://github.com/scylladb/cpp-driver/tree/master/topics/basics/prepared_statements/
-[`cass_int32_t`]: http://datastax.github.io/cpp-driver/api/cassandra.h/#cass-int32-t
+[`cass_int32_t`]: http://datastax.github.io/cpp-driver/api/cassandra.h#cass-int32-t
 [`cass_result_first_row()`]: http://datastax.github.io/cpp-driver/api/struct.CassResult/#cass-result-first-row
-[`cass_cluster_set_num_threads_io()`]: http://datastax.github.io/cpp-driver/api/struct.CassCluster/#function-cass_cluster_set_num_threads_io
-[`CassCluster`]: http://datastax.github.io/cpp-driver/api/struct.CassCluster/
-[`CassFuture`]: http://datastax.github.io/cpp-driver/api/struct.CassFuture/
-[`CassStatement`]: http://datastax.github.io/cpp-driver/api/struct.CassStatement/
-[`CassIterator`]: http://datastax.github.io/cpp-driver/api/struct.CassIterator/
-[`CassSession`]: http://datastax.github.io/cpp-driver/api/struct.CassSession/
+[`cass_cluster_set_num_threads_io()`]: http://datastax.github.io/cpp-driver/api/struct.CassCluster#function-cass_cluster_set_num_threads_io
+[`CassCluster`]: http://datastax.github.io/cpp-driver/api/struct.CassCluster
+[`CassFuture`]: http://datastax.github.io/cpp-driver/api/struct.CassFuture
+[`CassStatement`]: http://datastax.github.io/cpp-driver/api/struct.CassStatement
+[`CassIterator`]: http://datastax.github.io/cpp-driver/api/struct.CassIterator
+[`CassSession`]: http://datastax.github.io/cpp-driver/api/struct.CassSession
 [post]: http://www.datastax.com/dev/blog/4-simple-rules-when-using-the-datastax-drivers-for-cassandra
 [GH]: https://github.com/scylladb/cpp-driver/issues
 

--- a/topics/basics/binding_parameters/README.md
+++ b/topics/basics/binding_parameters/README.md
@@ -39,7 +39,7 @@ resize) a statement's parameters.
 
 ## Constructing Collections
 
-Collections are supported using [`CassCollection`](http://datastax.github.io/cpp-driver/api/struct.CassCollection/) objects; supporting `list`, `map` and `set` Cassandra types. The code below shows how to construct a `list` collection; however, a set can be constructed in a very similar way. The only difference is the type `CASS_COLLECTION_TYPE_SET` is used to create the collection instead of `CASS_COLLECTION_TYPE_LIST`.
+Collections are supported using [`CassCollection`](http://datastax.github.io/cpp-driver/api/struct.CassCollection) objects; supporting `list`, `map` and `set` Cassandra types. The code below shows how to construct a `list` collection; however, a set can be constructed in a very similar way. The only difference is the type `CASS_COLLECTION_TYPE_SET` is used to create the collection instead of `CASS_COLLECTION_TYPE_LIST`.
 
 **Important**: Values appended to the collection can be freed immediately afterward because the values are copied.
 
@@ -95,4 +95,4 @@ Custom types can be bound using either the `cass_statement_bind_bytes[_by_name](
 name of the custom type matches the class name of the type being bound.
 
 [`cass_collection_append_collection()`]:
-http://datastax.github.io/cpp-driver/api/struct.CassCollection/#cass-collection-append-collection
+http://datastax.github.io/cpp-driver/api/struct.CassCollection#cass-collection-append-collection

--- a/topics/basics/data_types/README.md
+++ b/topics/basics/data_types/README.md
@@ -132,13 +132,13 @@ cass_tuple_free(address);
 cass_collection_free(phone_numbers);
 ```
 
-[`CassDataType`]: http://datastax.github.io/cpp-driver/api/struct.CassDataType/
-[`CassUserType`]: http://datastax.github.io/cpp-driver/api/struct.CassUserType/
-[`CassPrepared`]: http://datastax.github.io/cpp-driver/api/struct.CassPrepared/
-[`CassResult`]: http://datastax.github.io/cpp-driver/api/struct.CassResult/
-[`CassValue`]: http://datastax.github.io/cpp-driver/api/struct.CassValue/
-[`CassSchemaMeta`]: http://datastax.github.io/cpp-driver/api/struct.CassSchemaMeta/
-[`cass_user_type_new_from_data_type()`]: http://datastax.github.io/cpp-driver/api/struct.CassUserType/#cass-user-type-new-from-data-type
-[`cass_result_column_data_type()`]: http://datastax.github.io/cpp-driver/api/struct.CassResult/#cass-result-column-data-type
-[`cass_prepared_parameter_data_type()`]: http://datastax.github.io/cpp-driver/api/struct.CassPrepared/#cass-prepared-parameter-data-type
-[`cass_value_data_type()`]: http://datastax.github.io/cpp-driver/api/struct.CassValue/#cass-value-data-type
+[`CassDataType`]: http://datastax.github.io/cpp-driver/api/struct.CassDataType
+[`CassUserType`]: http://datastax.github.io/cpp-driver/api/struct.CassUserType
+[`CassPrepared`]: http://datastax.github.io/cpp-driver/api/struct.CassPrepared
+[`CassResult`]: http://datastax.github.io/cpp-driver/api/struct.CassResult
+[`CassValue`]: http://datastax.github.io/cpp-driver/api/struct.CassValue
+[`CassSchemaMeta`]: http://datastax.github.io/cpp-driver/api/struct.CassSchemaMeta
+[`cass_user_type_new_from_data_type()`]: http://datastax.github.io/cpp-driver/api/struct.CassUserType#cass-user-type-new-from-data-type
+[`cass_result_column_data_type()`]: http://datastax.github.io/cpp-driver/api/struct.CassResult#cass-result-column-data-type
+[`cass_prepared_parameter_data_type()`]: http://datastax.github.io/cpp-driver/api/struct.CassPrepared#cass-prepared-parameter-data-type
+[`cass_value_data_type()`]: http://datastax.github.io/cpp-driver/api/struct.CassValue#cass-value-data-type

--- a/topics/basics/handling_results/README.md
+++ b/topics/basics/handling_results/README.md
@@ -1,6 +1,6 @@
 # Handling Results
 
-The [`CassResult`](http://datastax.github.io/cpp-driver/api/struct.CassResult/) object
+The [`CassResult`](http://datastax.github.io/cpp-driver/api/struct.CassResult) object
 is typically returned for `SELECT` statements. For mutations (`INSERT`, `UPDATE`,
 and `DELETE`) only a status code will be present and can be accessed using
 `cass_future_error_code()`. However, when using lightweight transactions a
@@ -28,7 +28,7 @@ void process_result(CassFuture* future) {
 
 The result object represents a collection of rows. The first row, if present,
 can be obtained using `cass_result_first_row()`. Multiple rows are accessed
-using a [`CassIterator`](http://datastax.github.io/cpp-driver/api/struct.CassIterator/)
+using a [`CassIterator`](http://datastax.github.io/cpp-driver/api/struct.CassIterator)
 object. After a row has been retrieved, the column value(s) can be accessed from
 a row by either index or by name. The iterator object can also be used with
 enumerated column values.
@@ -51,7 +51,7 @@ void process_first_row_by_name(const CassResult* result) {
 }
 ```
 
-Once the [`CassValue`](http://datastax.github.io/cpp-driver/api/struct.CassValue/)
+Once the [`CassValue`](http://datastax.github.io/cpp-driver/api/struct.CassValue)
 has been obtained from the column, the actual value can be retrieved and
 assigned into the proper datatype.
 
@@ -131,7 +131,7 @@ void iterator_over_map_value(CassFuture* future) {
 
 When communicating with Cassandra 2.0 or later, large result sets can be divided
 into multiple pages automatically. The
-[`CassResult`](http://datastax.github.io/cpp-driver/api/struct.CassResult/) object
+[`CassResult`](http://datastax.github.io/cpp-driver/api/struct.CassResult) object
 keeps track of the pagination state for the sequence of paging queries. When
 paging through the result set, the result object is checked to see if more pages
 exist where it is then attached to the statement before re-executing the query
@@ -187,6 +187,6 @@ accessed using [`cass_result_paging_state()`] and added to a statement using
 untrusted environments. That paging state could be spoofed and potentially used
 to gain access to other data.
 
-[`cass_statement_set_paging_state()`]: http://datastax.github.io/cpp-driver/api/struct.CassStatement/#cass-statement-set-paging-state
-[`cass_result_paging_state()`]: http://datastax.github.io/cpp-driver/api/struct.CassResult/#cass-result-paging-state
-[`cass_statement_set_paging_state_token()`]: http://datastax.github.io/cpp-driver/api/struct.CassStatement/#cass-statement-set-paging-state-token
+[`cass_statement_set_paging_state()`]: http://datastax.github.io/cpp-driver/api/struct.CassStatement#cass-statement-set-paging-state
+[`cass_result_paging_state()`]: http://datastax.github.io/cpp-driver/api/struct.CassResult#cass-result-paging-state
+[`cass_statement_set_paging_state_token()`]: http://datastax.github.io/cpp-driver/api/struct.CassStatement#cass-statement-set-paging-state-token

--- a/topics/basics/schema_metadata/README.md
+++ b/topics/basics/schema_metadata/README.md
@@ -58,4 +58,4 @@ cass_cluster_set_use_schema(cluster, cass_false);
 
 cass_cluster_free(cluster);
 ```
-[`cass_session_get_schema_meta()`]: http://datastax.github.io/cpp-driver/api/struct.CassSession/#cass-session-get-schema-meta
+[`cass_session_get_schema_meta()`]: http://datastax.github.io/cpp-driver/api/struct.CassSession#cass-session-get-schema-meta

--- a/topics/basics/tuples/README.md
+++ b/topics/basics/tuples/README.md
@@ -92,6 +92,6 @@ void iterate_tuple(const CassRow* row) {
 }
 ```
 
-[`CassTuple`]: http://datastax.github.io/cpp-driver/api/struct.CassTuple/
-[`CassUserType`]: http://datastax.github.io/cpp-driver/api/struct.CassUserType/
-[`cass_tuple_set_*()`]: http://datastax.github.io/cpp-driver/api/struct.CassTuple/#cass-tuple-set-null
+[`CassTuple`]: http://datastax.github.io/cpp-driver/api/struct.CassTuple
+[`CassUserType`]: http://datastax.github.io/cpp-driver/api/struct.CassUserType
+[`cass_tuple_set_*()`]: http://datastax.github.io/cpp-driver/api/struct.CassTuple#cass-tuple-set-null

--- a/topics/basics/user_defined_types/README.md
+++ b/topics/basics/user_defined_types/README.md
@@ -92,7 +92,7 @@ void iterate_udt(const CassRow* row) {
   cass_iterator_free(udt_iterator);
 }
 ```
-[`CassSchemaMeta`]: http://datastax.github.io/cpp-driver/api/struct.CassSchemaMeta/
-[`CassUserType`]: http://datastax.github.io/cpp-driver/api/struct.CassUserType/
-[`CassDataType`]: http://datastax.github.io/cpp-driver/api/struct.CassDataType/
-[`cass_session_get_schema()`]: http://datastax.github.io/cpp-driver/api/struct.CassSession/#cass-session-get-schema
+[`CassSchemaMeta`]: http://datastax.github.io/cpp-driver/api/struct.CassSchemaMeta
+[`CassUserType`]: http://datastax.github.io/cpp-driver/api/struct.CassUserType
+[`CassDataType`]: http://datastax.github.io/cpp-driver/api/struct.CassDataType
+[`cass_session_get_schema()`]: http://datastax.github.io/cpp-driver/api/struct.CassSession#cass-session-get-schema

--- a/topics/basics/uuids/README.md
+++ b/topics/basics/uuids/README.md
@@ -63,5 +63,5 @@ cass_uint8_t version = cass_uuid_version(uuid);
 char uuid_str[CASS_UUID_STRING_LENGTH];
 cass_uuid_string(uuid, uuid_str);
 ```
-[`cass_uuid_timestamp()`]: http://datastax.github.io/cpp-driver/api/struct.CassUuid/#1a3980467a0bb6642054ecf37d49aebf1a
-[`CassUuidGen`]: http://datastax.github.io/cpp-driver/api/struct.CassUuidGen/
+[`cass_uuid_timestamp()`]: http://datastax.github.io/cpp-driver/api/struct.CassUuid#1a3980467a0bb6642054ecf37d49aebf1a
+[`CassUuidGen`]: http://datastax.github.io/cpp-driver/api/struct.CassUuidGen

--- a/topics/configuration/README.md
+++ b/topics/configuration/README.md
@@ -451,11 +451,11 @@ recommended that your application decrease this value if computationally
 expensive or long-running future callbacks are used (via
 `cass_future_set_callback()`), otherwise this can be left unchanged.
 
-[`allow_remote_dcs_for_local_cl`]: http://datastax.github.io/cpp-driver/api/struct.CassCluster/#1a46b9816129aaa5ab61a1363489dccfd0
+[`allow_remote_dcs_for_local_cl`]: http://datastax.github.io/cpp-driver/api/struct.CassCluster#1a46b9816129aaa5ab61a1363489dccfd0
 [`OPTIONS`]: https://github.com/apache/cassandra/blob/cassandra-3.0/doc/native_protocol_v3.spec
-[token-aware]: http://datastax.github.io/cpp-driver/topics/configuration/#latency-aware-routing
-[latency-aware]: http://datastax.github.io/cpp-driver/topics/configuration/#token-aware-routing
-[paging]: http://datastax.github.io/cpp-driver/topics/basics/handling_results/#paging
+[token-aware]: http://datastax.github.io/cpp-driver/topics/configuration#latency-aware-routing
+[latency-aware]: http://datastax.github.io/cpp-driver/topics/configuration#token-aware-routing
+[paging]: http://datastax.github.io/cpp-driver/topics/basics/handling_results#paging
 
 ```eval_rst
 .. toctree::

--- a/topics/configuration/retry_policies/README.md
+++ b/topics/configuration/retry_policies/README.md
@@ -137,7 +137,7 @@ cass_retry_policy_free(logging_policy);
 
 cass_cluster_free(cluster);
 ```
-[`cass_cluster_set_retry_policy()`]: http://datastax.github.io/cpp-driver/api/struct.CassCluster/#cass-cluster-set-retry-policy
-[`cass_statement_set_retry_policy()`]: http://datastax.github.io/cpp-driver/api/struct.CassStatement/#cass-statement-set-retry-policy
-[`cass_batch_set_retry_policy()`]: http://datastax.github.io/cpp-driver/api/struct.CassBatch/#cass-batch-set-retry-policy
-[`CASS_LOG_INFO`]: http://datastax.github.io/cpp-driver/api/cassandra.h/#cass-log-level
+[`cass_cluster_set_retry_policy()`]: http://datastax.github.io/cpp-driver/api/struct.CassCluster#cass-cluster-set-retry-policy
+[`cass_statement_set_retry_policy()`]: http://datastax.github.io/cpp-driver/api/struct.CassStatement#cass-statement-set-retry-policy
+[`cass_batch_set_retry_policy()`]: http://datastax.github.io/cpp-driver/api/struct.CassBatch#cass-batch-set-retry-policy
+[`CASS_LOG_INFO`]: http://datastax.github.io/cpp-driver/api/cassandra.h#cass-log-level

--- a/topics/metrics/README.md
+++ b/topics/metrics/README.md
@@ -40,8 +40,8 @@ host. This can occur when too many requests are in-flight for a single host.
 Connection timeouts occur when the process of establishing new connections is
 unresponsive (default: 5 seconds).
 
-[`cass_session_get_metrics()`]: http://datastax.github.io/cpp-driver/api/struct.CassSession/#1ab3773670c98c00290bad48a6df0f9eae
-[`CassMetrics`]: http://datastax.github.io/cpp-driver/api/struct.CassMetrics/
-[`requests`]: http://datastax.github.io/cpp-driver/api/struct.CassMetrics/#attribute-requests
-[`stats`]: http://datastax.github.io/cpp-driver/api/struct.CassMetrics/#attribute-stats
-[`errors`]: http://datastax.github.io/cpp-driver/api/struct.CassMetrics/#attribute-errors
+[`cass_session_get_metrics()`]: http://datastax.github.io/cpp-driver/api/struct.CassSession#1ab3773670c98c00290bad48a6df0f9eae
+[`CassMetrics`]: http://datastax.github.io/cpp-driver/api/struct.CassMetrics
+[`requests`]: http://datastax.github.io/cpp-driver/api/struct.CassMetrics#attribute-requests
+[`stats`]: http://datastax.github.io/cpp-driver/api/struct.CassMetrics#attribute-stats
+[`errors`]: http://datastax.github.io/cpp-driver/api/struct.CassMetrics#attribute-errors

--- a/topics/security/README.md
+++ b/topics/security/README.md
@@ -136,7 +136,7 @@ int main() {
 ```
 
 
-[`cass_cluster_set_credentials()`]: http://datastax.github.io/cpp-driver/api/struct.CassCluster/#function-cass_cluster_set_credentials_n
+[`cass_cluster_set_credentials()`]: http://datastax.github.io/cpp-driver/api/struct.CassCluster#function-cass_cluster_set_credentials_n
 
 ```eval_rst
 .. toctree::

--- a/topics/security/ssl/README.md
+++ b/topics/security/ssl/README.md
@@ -59,7 +59,7 @@ The following [guide](http://www.datastax.com/documentation/cassandra/2.1/cassan
 
 ## Setting up the C/C++ Driver to Use SSL
 
-A [`CassSsl`](http://datastax.github.io/cpp-driver/api/struct.CassSsl/) object is required and must be configured:
+A [`CassSsl`](http://datastax.github.io/cpp-driver/api/struct.CassSsl) object is required and must be configured:
 
 ```c
 #include <cassandra.h>

--- a/topics/testing/README.md
+++ b/topics/testing/README.md
@@ -116,7 +116,7 @@ Here are some of the items being scheduled for future enhancements.
 - Updates to CCM Bridge
  - Allow files to be copied over SSH established connection
 
-[build procedures]: http://datastax.github.io/cpp-driver/topics/building/#test-dependencies-and-building-tests-not-required
+[build procedures]: http://datastax.github.io/cpp-driver/topics/building#test-dependencies-and-building-tests-not-required
 
 ```eval_rst
 .. toctree::


### PR DESCRIPTION
Closes https://github.com/scylladb/cpp-driver/issues/66

Sphinx replaces "datastax.github.io" links to "cpp-driver.docs.scylladb.com" automatically.
The problem is that the documents under https://cpp-driver.docs.scylladb.com/master/api/ do not accept a trailing slash. 

For example:

- https://cpp-driver.docs.scylladb.com/master/api/struct.CassFuture/ - Returns a 404
- https://cpp-driver.docs.scylladb.com/master/api/struct.CassFuture - Returns the expected content

This PR removes the trailing slash of the affected links.