### PR TITLE
Fix building ExportedConnection on Windows

### DIFF
--- a/src/exported_connection.hpp
+++ b/src/exported_connection.hpp
@@ -40,7 +40,7 @@ private:
     unsigned int heartbeat_interval_secs_;
 
     // Socket fields
-    int fd;
+    uv_os_sock_t fd;
     SocketHandlerBase *handler_;
     bool is_defunct_;
     size_t max_reusable_write_objects_;


### PR DESCRIPTION
The `<unistd.h>` header isn't available on Windows. The `dup` function is deprecated[^1] and apparently also not the correct function here.

On Windows `uv_fileno` currently returns a `SOCKET`[^2] cast into `uv_os_fd_t`[^3]. Contrary to many other handles this handle type can't be duplicated using `DuplicateHandle`[^4]. `WSADuplicateSocket` has to be used instead. As documented an actual `SOCKET` has to be constructed from `WSAPROTOCOL_INFOW`.  The parameters are taken from the struct, except for `g` and `dwFlags` which were taken from libuv's implementation[^5].

Error handling was omitted like with `uv_fileno` and `dup` already.

Also changed the type of `fd` to what `uv_tcp_open` expects which is `SOCKET` instead of `int` on Windows.

[^1]: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/posix-dup-dup2
[^2]: https://github.com/libuv/libuv/blob/2f1614b1286f53b3b2ab96a15a525cb25462ba9a/include/uv/win.h#L456
[^3]: https://github.com/libuv/libuv/blob/2f1614b1286f53b3b2ab96a15a525cb25462ba9a/src/win/core.c#L689
[^4]: https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-duplicatehandle#remarks
[^5]: https://github.com/libuv/libuv/blob/2f1614b1286f53b3b2ab96a15a525cb25462ba9a/src/win/tcp.c#L1281-L1282