### PR TITLE
Remove AGPL license comments from the driver

### DIFF
--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -4,8 +4,7 @@ Source: https://github.com/scylladb/cpp-driver
 
 Files: *
 Copyright: Copyright (c) DataStax, Inc.
- Copyright (c) 2020 ScyllaDB
-License: Apache-2.0, AGPL-3
+License: Apache-2.0
   On Debian systems, the complete text of the Apache License Version 2.0
   can be found in `/usr/share/common-licenses/Apache-2.0'.
 

--- a/src/optional.hpp
+++ b/src/optional.hpp
@@ -1,22 +1,3 @@
-/*
- * Copyright (C) 2020 ScyllaDB 
- *
- * This file is part of Scylla.
- *
- * Scylla is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Scylla is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 #ifndef DATASTAX_INTERNAL_OPTIONAL_HPP
 #define DATASTAX_INTERNAL_OPTIONAL_HPP
 

--- a/src/optional/optional_akrzemi.hpp
+++ b/src/optional/optional_akrzemi.hpp
@@ -7,26 +7,6 @@
 // The idea and interface is based on Boost.Optional library
 // authored by Fernando Luis Cacciola Carballal
 
-/*
- * Modified by ScyllaDB
- * Copyright (C) 2020 ScyllaDB 
- *
- * This file is part of Scylla.
- *
- * Scylla is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Scylla is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 # ifndef OPTIONAL_AKRZEMI_HPP
 # define OPTIONAL_AKRZEMI_HPP
 


### PR DESCRIPTION
The AGPL license comments were added in some files as an auto-choice as it is currently used in Scylla, however, they are not necessary and we can stick to Apache-2.0.