### PR TITLE
docs: update command

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -26,11 +26,14 @@ setupenv:
 .PHONY: setup
 setup:
 	$(POETRY) install
-	$(POETRY) update
 	cd .. && doxygen Doxyfile.in
 	@if [ ! -d "$(SOURCEDIR)" ]; then mkdir -p "$(SOURCEDIR)"; fi
 	cp -RL source/* $(SOURCEDIR)
 	cd $(SOURCEDIR) && find . -name README.md -execdir mv '{}' index.md ';'
+
+.PHONY: update
+update:
+	$(POETRY) update
 
 # Clean commands
 .PHONY: pristine


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/849

Separates the update command from the setup command.

This is required because versions now are not strictly pinned in the `pyproject.toml` file since Sphinx ScyllaDB Theme 1.8. This change makes sure that the versions defined in the ``poetry.lock`` file committed to the repository are the ones used for production builds.

## How to test

1. Build the docs locally with ``make preview``.
2. Check ``poetry.lock`` dependencies are not updated.