### PR TITLE
silence compiler Werror about nontrivial pointer operand to memset

### DIFF
--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -144,7 +144,7 @@ void Md5::final(uint8_t* result) {
   result[14] = static_cast<uint8_t>(d_ >> 16);
   result[15] = static_cast<uint8_t>(d_ >> 24);
 
-  memset(this, 0, sizeof(Md5));
+  memset(static_cast<void*>(this), 0, sizeof(Md5));
 }
 
 // This processes one or more 64-byte data blocks, but does NOT update


### PR DESCRIPTION
Error
=======
```
cass-cpp-src/src/md5.cpp:147:10: error: first argument in call to 'memset' is a pointer to non-trivially copyable type 'datastax::internal::Md5' [-Werror,-Wnontrivial-memcall]
  147 |   memset(this, 0, sizeof(Md5));
      |          ^
cass-cpp-src/src/md5.cpp:147:10: note: explicitly cast the pointer to silence this warning
  147 |   memset(this, 0, sizeof(Md5));
      |          ^
      |          (void*)
1 error generated.
```

Patch
========
```diff
diff --git a/src/md5.cpp b/src/md5.cpp
index 724ca2ce..c5494b1e 100644
--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -144,7 +144,7 @@ void Md5::final(uint8_t* result) {
   result[14] = static_cast<uint8_t>(d_ >> 16);
   result[15] = static_cast<uint8_t>(d_ >> 24);
 
-  memset(this, 0, sizeof(Md5));
+  memset(static_cast<void*>(this), 0, sizeof(Md5));
 }
 
 // This processes one or more 64-byte data blocks, but does NOT update
```

Build is broken on upstream too.