### PR TITLE
Fix comment on default timestamp generator

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -10939,8 +10939,6 @@ cass_uuid_from_string_n(const char* str,
  * Creates a new server-side timestamp generator. This generator allows Cassandra
  * to assign timestamps server-side.
  *
- * <b>Note:</b> This is the default timestamp generator.
- *
  * @cassandra{2.1+}
  *
  * @public @memberof CassTimestampGen
@@ -10969,7 +10967,7 @@ cass_timestamp_gen_server_side_new();
  * instance.
  *
  * <b>Note:</b> This generator is thread-safe and can be shared by multiple
- * sessions.
+ * sessions. It is the default timestamp generator.
  *
  * @cassandra{2.1+}
  *


### PR DESCRIPTION
When `cass_cluster_set_timestamp_gen` was introduced in 57d1a8afb0013a09345affdb7d633c292418912b the comment on the then default timestamp generator was added. The default was later changed in c705ea54a562a657248c7ff7b987b35c2fda2cc9 but this comment was missed in the adjustments of the documentation.